### PR TITLE
 Function split() is deprecated

### DIFF
--- a/snmp.php
+++ b/snmp.php
@@ -518,7 +518,7 @@ function format_snmp_string($string, $snmp_oid_included) {
 		$string = preg_replace('/Hex: ?/i', '', $string);
 		$string = preg_replace('/Hex- ?/i', '', $string);
 
-		$string_array = split(' ', $string);
+		$string_array = explode(' ', $string);
 
 		/* loop through each string character and make ascii */
 		$string = '';


### PR DESCRIPTION
ERROR PHP DEPRECATED in Plugin 'mikrotik': Function split() is deprecated in file: /var/www/cacti/plugins/mikrotik/snmp.php on line: 521