### PR TITLE
Correct default timestamp format

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -674,7 +674,7 @@ function mikrotik_setup_table() {
 		`disabled` varchar(5) NOT NULL,
 		`list` varchar(20) NOT NULL,
 		`address` varchar(60) NOT NULL,
-		`created` timestamp NOT NULL DEFAULT '1970-01-01',
+		`created` timestamp NOT NULL DEFAULT '1970-01-01 00:00:01',
 		`timeout` int(11) NOT NULL default '-1',
 		`present` tinyint unsigned NOT NULL default '1',
 		`last_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,


### PR DESCRIPTION
Correct this error:

2020-08-18 14:55:31 - CMDPHP SQL Backtrace: (/plugins.php[74]:api_plugin_install(), /lib/plugins.php[625]:plugin_mikrotik_install(), /plugins/mikrotik/setup.php[41]:mikrotik_setup_table(), /plugins/mikrotik/setup.php[670]:db_execute(), /lib/database.php[213]:db_execute_prepared())
--
2020-08-18 14:55:31 - CMDPHP ERROR: A DB Exec Failed!, Error: Invalid default value for 'created'

