### PR TITLE
Fix minor spelling errors

### DIFF
--- a/locales/po/ar-SA.po
+++ b/locales/po/ar-SA.po
@@ -771,7 +771,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/bg-BG.po
+++ b/locales/po/bg-BG.po
@@ -774,7 +774,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/cacti.pot
+++ b/locales/po/cacti.pot
@@ -636,7 +636,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/de-DE.po
+++ b/locales/po/de-DE.po
@@ -774,7 +774,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/el-GR.po
+++ b/locales/po/el-GR.po
@@ -776,7 +776,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/es-ES.po
+++ b/locales/po/es-ES.po
@@ -764,7 +764,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/fr-FR.po
+++ b/locales/po/fr-FR.po
@@ -776,7 +776,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/he-IL.po
+++ b/locales/po/he-IL.po
@@ -768,7 +768,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/hi-IN.po
+++ b/locales/po/hi-IN.po
@@ -770,7 +770,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/it-IT.po
+++ b/locales/po/it-IT.po
@@ -774,7 +774,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/ja-JP.po
+++ b/locales/po/ja-JP.po
@@ -768,7 +768,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/ko-KR.po
+++ b/locales/po/ko-KR.po
@@ -768,7 +768,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/nl-NL.po
+++ b/locales/po/nl-NL.po
@@ -774,7 +774,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/pl-PL.po
+++ b/locales/po/pl-PL.po
@@ -767,7 +767,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/pt-BR.po
+++ b/locales/po/pt-BR.po
@@ -773,7 +773,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/pt-PT.po
+++ b/locales/po/pt-PT.po
@@ -773,7 +773,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/ru-RU.po
+++ b/locales/po/ru-RU.po
@@ -773,7 +773,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/sv-SE.po
+++ b/locales/po/sv-SE.po
@@ -772,7 +772,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/tr-TR.po
+++ b/locales/po/tr-TR.po
@@ -773,7 +773,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/vi-VN.po
+++ b/locales/po/vi-VN.po
@@ -771,7 +771,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/locales/po/zh-CN.po
+++ b/locales/po/zh-CN.po
@@ -651,7 +651,7 @@ msgstr "DHCP注册"
 
 #: ../setup.php:743
 #, fuzzy
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr "DHCP注册"
 
 #: ../setup.php:744

--- a/locales/po/zh-TW.po
+++ b/locales/po/zh-TW.po
@@ -764,7 +764,7 @@ msgid "DHCP Settings"
 msgstr ""
 
 #: ../setup.php:743
-msgid "DHCP Renetion"
+msgid "DHCP Retention"
 msgstr ""
 
 #: ../setup.php:744

--- a/setup.php
+++ b/setup.php
@@ -781,21 +781,21 @@ function mikrotik_config_settings() {
 			'method' => 'spacer',
 			),
 		'mikrotik_dhcp_retention' => array(
-			'friendly_name' => __('DHCP Renetion', 'mikrotik'),
+			'friendly_name' => __('DHCP Retention', 'mikrotik'),
 			'description' => __('How long would you like to retain DHCP IP registration history?', 'mikrotik'),
 			'method' => 'drop_array',
 			'default' => '2419200',
 			'array' => $mikrotik_retention
 			),
 		'mikrotik_dns_retention' => array(
-			'friendly_name' => __('DNS Renetion', 'mikrotik'),
+			'friendly_name' => __('DNS Retention', 'mikrotik'),
 			'description' => __('How long would you like to retain DNS Cache history?', 'mikrotik'),
 			'method' => 'drop_array',
 			'default' => '2419200',
 			'array' => $mikrotik_retention
 			),
 		'mikrotik_list_retention' => array(
-			'friendly_name' => __('Address List Renetion', 'mikrotik'),
+			'friendly_name' => __('Address List Retention', 'mikrotik'),
 			'description' => __('How long would you like to retain Address List history?', 'mikrotik'),
 			'method' => 'drop_array',
 			'default' => '2419200',


### PR DESCRIPTION
Replace all instances of 'Renetion' with 'Retention'.