### PR TITLE
Fixed errors

### DIFF
--- a/poller_mikrotik.php
+++ b/poller_mikrotik.php
@@ -781,7 +781,7 @@ function checkHost($host_id) {
 			// Remove old records
 			db_execute_prepared('DELETE FROM plugin_mikrotik_users
 				WHERE userType=0
-				AND name RLIKE '" . read_config_option('mikrotik_user_exclusion') . "'
+				AND name RLIKE ' . read_config_option('mikrotik_user_exclusion') . '
 				AND present = 0
 				AND host_id = ?
 				AND last_seen < FROM_UNIXTIME(UNIX_TIMESTAMP()-' . read_config_option('mikrotik_user_exclusion_ttl') . ')',


### PR DESCRIPTION
Script generated PHP parse error:

PHP Parse error:  syntax error, unexpected double-quoted string " . read_config_option('mikroti...", expecting ")" in /root/plugin_mikrotik/poller_mikrotik.php on line 784

Fixed it